### PR TITLE
VS project fixes

### DIFF
--- a/quakespasm/Windows/VisualStudio/quakespasm-sdl2.vcproj
+++ b/quakespasm/Windows/VisualStudio/quakespasm-sdl2.vcproj
@@ -40,7 +40,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="0"
-				AdditionalIncludeDirectories="..\SDL2\include;..\codecs\include;..\misc\include;..\..\Quake"
+				AdditionalIncludeDirectories="..\SDL2\include;..\codecs\include;..\misc\include;..\..\Quake;$(VC_IncludePath);$(WindowsSDK_IncludePath)"
 				PreprocessorDefinitions="WIN32;_DEBUG;_WINDOWS;_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;USE_SDL2;USE_CODEC_MP3;USE_CODEC_VORBIS;USE_CODEC_WAVE;USE_CODEC_FLAC;USE_CODEC_OPUS;USE_CODEC_MIKMOD;USE_CODEC_UMX"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
@@ -61,9 +61,9 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				AdditionalDependencies="libvorbisfile.lib libvorbis.lib libopusfile.lib libopus.lib libFLAC.lib libogg.lib libmad.lib libmikmod.lib wsock32.lib opengl32.lib winmm.lib SDL2.lib SDL2main.lib"
+				AdditionalDependencies="libvorbisfile.lib libvorbis.lib libopusfile.lib libopus.lib libFLAC.lib libogg.lib libmad.lib libmikmod.lib wsock32.lib opengl32.lib winmm.lib SDL2.lib SDL2main.lib Ws2_32.lib"
 				LinkIncremental="2"
-				AdditionalLibraryDirectories="..\codecs\x86;..\SDL2\lib"
+				AdditionalLibraryDirectories="..\codecs\x86;..\SDL2\lib;$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86)"
 				IgnoreDefaultLibraryNames="msvcrt.lib"
 				GenerateDebugInformation="true"
 				SubSystem="2"
@@ -116,7 +116,7 @@
 				Name="VCCLCompilerTool"
 				Optimization="2"
 				EnableIntrinsicFunctions="true"
-				AdditionalIncludeDirectories="..\SDL2\include;..\codecs\include;..\misc\include;..\..\Quake"
+				AdditionalIncludeDirectories="..\SDL2\include;..\codecs\include;..\misc\include;..\..\Quake;$(VC_IncludePath);$(WindowsSDK_IncludePath)"
 				PreprocessorDefinitions="WIN32;NDEBUG;_WINDOWS;_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;USE_SDL2;USE_CODEC_MP3;USE_CODEC_VORBIS;USE_CODEC_WAVE;USE_CODEC_FLAC;USE_CODEC_OPUS;USE_CODEC_MIKMOD;USE_CODEC_UMX"
 				RuntimeLibrary="2"
 				EnableFunctionLevelLinking="true"
@@ -136,9 +136,9 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				AdditionalDependencies="libvorbisfile.lib libvorbis.lib libopusfile.lib libopus.lib libFLAC.lib libogg.lib libmad.lib libmikmod.lib wsock32.lib opengl32.lib winmm.lib SDL2.lib SDL2main.lib"
+				AdditionalDependencies="libvorbisfile.lib libvorbis.lib libopusfile.lib libopus.lib libFLAC.lib libogg.lib libmad.lib libmikmod.lib wsock32.lib opengl32.lib winmm.lib SDL2.lib SDL2main.lib Ws2_32.lib"
 				LinkIncremental="1"
-				AdditionalLibraryDirectories="..\codecs\x86;..\SDL2\lib"
+				AdditionalLibraryDirectories="..\codecs\x86;..\SDL2\lib;$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86)"
 				GenerateDebugInformation="true"
 				SubSystem="2"
 				OptimizeReferences="2"
@@ -191,7 +191,7 @@
 			<Tool
 				Name="VCCLCompilerTool"
 				Optimization="0"
-				AdditionalIncludeDirectories="..\SDL2\include;..\codecs\include;..\misc\include;..\..\Quake"
+				AdditionalIncludeDirectories="..\SDL2\include;..\codecs\include;..\misc\include;..\..\Quake;$(VC_IncludePath);$(WindowsSDK_IncludePath)"
 				PreprocessorDefinitions="WIN32;_DEBUG;_WINDOWS;_USE_WINSOCK2;_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;USE_SDL2;USE_CODEC_MP3;USE_CODEC_VORBIS;USE_CODEC_WAVE;USE_CODEC_FLAC;USE_CODEC_OPUS;USE_CODEC_MIKMOD;USE_CODEC_UMX"
 				MinimalRebuild="true"
 				BasicRuntimeChecks="3"
@@ -212,9 +212,9 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				AdditionalDependencies="libvorbisfile.lib libvorbis.lib libopusfile.lib libopus.lib libFLAC.lib libogg.lib libmad.lib libmikmod.lib ws2_32.lib opengl32.lib winmm.lib SDL2.lib SDL2main.lib"
+				AdditionalDependencies="libvorbisfile.lib libvorbis.lib libopusfile.lib libopus.lib libFLAC.lib libogg.lib libmad.lib libmikmod.lib ws2_32.lib opengl32.lib winmm.lib SDL2.lib SDL2main.lib Ws2_32.lib"
 				LinkIncremental="2"
-				AdditionalLibraryDirectories="..\codecs\x64;..\SDL2\lib64"
+				AdditionalLibraryDirectories="..\codecs\x64;..\SDL2\lib64;$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)"
 				IgnoreDefaultLibraryNames="msvcrt.lib"
 				GenerateDebugInformation="true"
 				SubSystem="2"
@@ -268,7 +268,7 @@
 				Name="VCCLCompilerTool"
 				Optimization="2"
 				EnableIntrinsicFunctions="true"
-				AdditionalIncludeDirectories="..\SDL2\include;..\codecs\include;..\misc\include;..\..\Quake"
+				AdditionalIncludeDirectories="..\SDL2\include;..\codecs\include;..\misc\include;..\..\Quake;$(VC_IncludePath);$(WindowsSDK_IncludePath)"
 				PreprocessorDefinitions="WIN32;NDEBUG;_WINDOWS;_USE_WINSOCK2;_CRT_NONSTDC_NO_DEPRECATE;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;USE_SDL2;USE_CODEC_MP3;USE_CODEC_VORBIS;USE_CODEC_WAVE;USE_CODEC_FLAC;USE_CODEC_OPUS;USE_CODEC_MIKMOD;USE_CODEC_UMX"
 				RuntimeLibrary="2"
 				EnableFunctionLevelLinking="true"
@@ -288,9 +288,9 @@
 			/>
 			<Tool
 				Name="VCLinkerTool"
-				AdditionalDependencies="libvorbisfile.lib libvorbis.lib libopusfile.lib libopus.lib libFLAC.lib libogg.lib libmad.lib libmikmod.lib ws2_32.lib opengl32.lib winmm.lib SDL2.lib SDL2main.lib"
+				AdditionalDependencies="libvorbisfile.lib libvorbis.lib libopusfile.lib libopus.lib libFLAC.lib libogg.lib libmad.lib libmikmod.lib ws2_32.lib opengl32.lib winmm.lib SDL2.lib SDL2main.lib Ws2_32.lib"
 				LinkIncremental="1"
-				AdditionalLibraryDirectories="..\codecs\x64;..\SDL2\lib64"
+				AdditionalLibraryDirectories="..\codecs\x64;..\SDL2\lib64;$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)"
 				GenerateDebugInformation="true"
 				SubSystem="2"
 				OptimizeReferences="2"


### PR DESCRIPTION
I had to make some fixes to the VS project to get it to build on my system (Wwindows 10, VS2019) 

- the "winsock2.h" include was not found: adding `$(VC_IncludePath);$(WindowsSDK_IncludePath)` fixed this
- undefined reference to __imp__freeaddrinfo@4: linking Ws2_32.lib fixed this

Both the x86 and x64 SDL2 projects now build and work