### PR TITLE
Fix compatibility with MSVC

### DIFF
--- a/quakespasm/Quake/world.h
+++ b/quakespasm/Quake/world.h
@@ -73,7 +73,7 @@ int SV_TruePointContents (vec3_t p);
 
 edict_t	*SV_TestEntityPosition (edict_t *ent);
 
-#define CONTENTMASK_FROMQ1(c) (1u<<(-c))
+#define CONTENTMASK_FROMQ1(c) (1u<<(-(c)))
 #define CONTENTMASK_ANYSOLID (CONTENTMASK_FROMQ1(CONTENTS_SOLID) | CONTENTMASK_FROMQ1(CONTENTS_CLIP))
 trace_t SV_ClipMoveToEntity (edict_t *ent, vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end, unsigned int hitcontents);
 trace_t SV_Move (vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end, int type, edict_t *passedict);

--- a/quakespasm/Windows/VisualStudio/quakespasm-sdl2.vcproj
+++ b/quakespasm/Windows/VisualStudio/quakespasm-sdl2.vcproj
@@ -470,6 +470,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\..\Quake\mdfour.c"
+				>
+			</File>
+			<File
 				RelativePath="..\..\Quake\menu.c"
 				>
 			</File>

--- a/quakespasm/Windows/VisualStudio/quakespasm.vcproj
+++ b/quakespasm/Windows/VisualStudio/quakespasm.vcproj
@@ -466,6 +466,10 @@
 				>
 			</File>
 			<File
+				RelativePath="..\..\Quake\mdfour.c"
+				>
+			</File>
+			<File
 				RelativePath="..\..\Quake\menu.c"
 				>
 			</File>


### PR DESCRIPTION
Two quick & small changes so the project works on VS again:

- MSVC can't parse a certain macro that's supposed to negate a negative number, instead it becomes `--`, fixed with a pair of parenthesis
- The VS projects were missing mdfour.c
