### PR TITLE
Fix Scaled Models Dissappearing Due to Bounds not in View

### DIFF
--- a/Quake/gl_rmain.c
+++ b/Quake/gl_rmain.c
@@ -303,21 +303,41 @@ R_CullModelForEntity -- johnfitz -- uses correct bounds based on rotation
 qboolean R_CullModelForEntity (entity_t *e)
 {
 	vec3_t mins, maxs;
+	vec3_t minbounds, maxbounds;
 
 	if (e->angles[0] || e->angles[2]) //pitch or roll
 	{
-		VectorAdd (e->origin, e->model->rmins, mins);
-		VectorAdd (e->origin, e->model->rmaxs, maxs);
+		VectorCopy (e->model->rmins, minbounds);
+		VectorCopy (e->model->rmaxs, maxbounds);
+
 	}
 	else if (e->angles[1]) //yaw
 	{
-		VectorAdd (e->origin, e->model->ymins, mins);
-		VectorAdd (e->origin, e->model->ymaxs, maxs);
+		VectorCopy (e->model->ymins, minbounds);
+		VectorCopy (e->model->ymaxs, maxbounds);
 	}
 	else //no rotation
 	{
-		VectorAdd (e->origin, e->model->mins, mins);
-		VectorAdd (e->origin, e->model->maxs, maxs);
+		VectorCopy (e->model->mins, minbounds);
+		VectorCopy (e->model->maxs, maxbounds);
+	}
+
+	vec_t scalefactor =  e->netstate.scale/16.0f;
+	if (scalefactor < 0.001f)
+		scalefactor = 1.0f;
+
+	if (scalefactor != 1.0f)
+	{
+		vec3_t scaledVec;
+		VectorScale (minbounds, scalefactor, scaledVec);
+		VectorAdd (e->origin, scaledVec, mins);
+		VectorScale (maxbounds, scalefactor, scaledVec);
+		VectorAdd (e->origin, scaledVec, maxs);
+	}
+	else
+	{
+		VectorAdd (e->origin, minbounds, mins);
+		VectorAdd (e->origin, maxbounds, maxs);
 	}
 
 	return R_CullBox (mins, maxs);

--- a/Quake/snd_mem.c
+++ b/Quake/snd_mem.c
@@ -186,13 +186,13 @@ sfxcache_t *S_LoadSound (sfx_t *s)
 	info = GetWavinfo (s->name, data, com_filesize);
 	if (info.channels != 1 && info.channels != 2)
 	{
-		Con_Printf ("%s is a stereo sample\n",s->name);
+		Con_Printf ("%s is a stereo sample, not loaded!\n",s->name);
 		return NULL;
 	}
 
 	if (info.width != 1 && info.width != 2)
 	{
-		Con_Printf("%s is not 8 or 16 bit\n", s->name);
+		Con_Printf("%s is not 8 or 16 bit, not loaded!\n", s->name);
 		return NULL;
 	}
 
@@ -203,7 +203,7 @@ sfxcache_t *S_LoadSound (sfx_t *s)
 
 	if (info.samples == 0 || len == 0)
 	{
-		Con_Printf("%s has zero samples\n", s->name);
+		Con_Printf("%s has zero samples, not loaded!\n", s->name);
 		return NULL;
 	}
 


### PR DESCRIPTION
Update R_CullModelForEntity to scale visibility bounds so that scaled models do not pop in and out of view.  Most noticeable for misc_model decorations scaled up, though can affect func_illusionary hacks as well in vanilla.

Tossed in a tiny update to a few sound warnings that were not at all clear.