### PR TITLE
Fix joystick movement being framerate-dependent

### DIFF
--- a/Quake/cl_main.c
+++ b/Quake/cl_main.c
@@ -1268,9 +1268,9 @@ void CL_SendCmd (void)
 	CL_BaseMove (&cmd);
 
 	// allow mice or other external controllers to add to the move
-	cmd.forwardmove	+= cl.pendingcmd.forwardmove;
-	cmd.sidemove	+= cl.pendingcmd.sidemove;
-	cmd.upmove		+= cl.pendingcmd.upmove;
+	cmd.forwardmove	+= cl.pendingcmd.forwardmove + cl.pendingcmd.forwardmove_accumulator;
+	cmd.sidemove	+= cl.pendingcmd.sidemove + cl.pendingcmd.sidemove_accumulator;
+	cmd.upmove		+= cl.pendingcmd.upmove + cl.pendingcmd.upmove_accumulator;
 	cmd.sequence	= cl.movemessages;
 	cmd.servertime	= cl.time;
 	cmd.seconds		= cmd.servertime - cl.pendingcmd.servertime;

--- a/Quake/in_sdl.c
+++ b/Quake/in_sdl.c
@@ -864,7 +864,7 @@ void IN_MouseMove(usercmd_t *cmd)
 	total_dy = 0;
 
 	if ( (in_strafe.state & 1) || (lookstrafe.value && (in_mlook.state & 1) ))
-		cmd->sidemove += m_side.value * dmx;
+		cmd->sidemove_accumulator += m_side.value * dmx;
 	else
 		cl.viewangles[YAW] -= m_yaw.value * dmx * cl.csqc_sensitivity;
 
@@ -886,14 +886,19 @@ void IN_MouseMove(usercmd_t *cmd)
 	else
 	{
 		if ((in_strafe.state & 1) && noclip_anglehack)
-			cmd->upmove -= m_forward.value * dmy;
+			cmd->upmove_accumulator -= m_forward.value * dmy;
 		else
-			cmd->forwardmove -= m_forward.value * dmy;
+			cmd->forwardmove_accumulator -= m_forward.value * dmy;
 	}
 }
 
 void IN_Move(usercmd_t *cmd)
 {
+	// We only want the latest joystick movements
+	cmd->forwardmove = 0;
+	cmd->sidemove = 0;
+	cmd->upmove = 0;
+
 	IN_JoyMove(cmd);
 	IN_MouseMove(cmd);
 }

--- a/Quake/protocol.h
+++ b/Quake/protocol.h
@@ -512,6 +512,11 @@ typedef struct
 	float	sidemove;
 	float	upmove;
 
+// used by client for mouse-based movements that should accumulate over multiple client frames
+	float	forwardmove_accumulator;
+	float	sidemove_accumulator;
+	float	upmove_accumulator;
+
 	unsigned int	buttons;
 	unsigned int	impulse;
 


### PR DESCRIPTION
This fixes a bug that when host_maxfps > 72, movement joystick sensitivity would effectively raise proportionally with the framerate. Pushing the stick halfway would make you walk at 72 fps but make you run at maximum speed at 180 fps, etc.

This is because the joystick movement would be summed together over multiple client frames. Only mouse-based movement should be summed together over multiple frames. For joystick-based movement, only the most recent values should be used.