### PR TITLE
Continuous integration for Windows and Linux

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,0 +1,24 @@
+name: Linux CI
+
+on: 
+  push
+
+jobs:
+  build-linux:
+    name: Build Linux
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: ["clang", "gcc"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Dependencies
+        run: sudo apt update && sudo apt install libmad0-dev libopusfile-dev libsdl2-dev libvorbis-dev
+
+      - name: Build with ${{ matrix.compiler }}
+        run: |
+          export MAKEFLAGS=--jobs=3\ --keep-going
+          make --jobs=3 --keep-going --directory=Quake CC=${{ matrix.compiler }} USE_SDL2=1

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,28 +1,25 @@
-name: Auto Build
+name: macOS CI
 
 on:
   push
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    name: Build macOS
+    runs-on: macos-12
     strategy:
       fail-fast: false
-      matrix:
-        os: [macos-12]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: macOS Build
-      if: runner.os == 'macOS'
       run: |
           cd MacOSX
           ./build-macos.sh
 
     - name: Upload macOS artifact
-      uses: actions/upload-artifact@v2
-      if: runner.os == 'macOS'
+      uses: actions/upload-artifact@v3
       with:
         name: macos
         path: |

--- a/.github/workflows/build-mingw.yml
+++ b/.github/workflows/build-mingw.yml
@@ -1,0 +1,29 @@
+name: MinGW CI
+
+on: 
+  push
+
+jobs:
+  build-linux:
+    name: Build MinGW
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - target: win32
+            package: i686-win32
+
+          - target: win64
+            package: x86-64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Dependencies
+        run: sudo apt update && sudo apt install gcc-mingw-w64-${{ matrix.config.package }} libz-mingw-w64-dev
+
+      - name: Build with MinGW ${{ matrix.config.target }}
+        run: |
+          export MAKEFLAGS=--jobs=3\ --keep-going
+          cd Quake && ./build_cross_${{ matrix.config.target }}-sdl2.sh


### PR DESCRIPTION
Links to builds: [Linux](https://github.com/alexey-lysiuk/quakespasm-spiked/actions/runs/7142434834), [macOS](https://github.com/alexey-lysiuk/quakespasm-spiked/actions/runs/7142434835), [MinGW](https://github.com/alexey-lysiuk/quakespasm-spiked/actions/runs/7142434832).

Windows builds are slower than the rest because they require Visual Studio to update projects and solution. MSBuild cannot handle pre-VS2010 format without conversion, and it took up to 5 minutes to configure VS during the first launch.

@Shpoike let me know if you want use CMake instead of Make on Linux.