### PR TITLE
Install GnuTLS to fix Linux continuous integration jobs

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Dependencies
-        run: sudo apt update && sudo apt install libmad0-dev libopusfile-dev libsdl2-dev libvorbis-dev
+        run: sudo apt update && sudo apt install libgnutls28-dev libmad0-dev libopusfile-dev libsdl2-dev libvorbis-dev
 
       - name: Build with ${{ matrix.compiler }}
         run: |


### PR DESCRIPTION
[Succeeded Linux build jobs](https://github.com/alexey-lysiuk/quakespasm-spiked/actions/runs/15804448637).